### PR TITLE
Add CI pipeline with ruff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install ruff
+      - name: Check formatting
+        run: |
+          ruff format src tests --check
+      - name: Lint with ruff
+        run: |
+          ruff check src tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,16 +50,10 @@ ignore = [
   "TD", # flake8-todos
   "FIX", # flake8-fixme
   "ANN", # flake8-annotations (handled by mypy)
-  "EM", # flake8-errmsg - String literals in exceptions
   "E501", # pycodestyle - line too long (handled by formatter)
   "COM812", # forced by ruff formatter
   "ISC001", # forced by ruff formatter
-  "TRY003", # long message for exceptions
-  "EM101", # allow string literals for exceptions
-  "EM102", # allow f-string literals for exceptions
-  "FBT001",  # Boolean-typed positional argument in function definition
   "INP001", # part of an implicit namespace package. Add an `__init__.py`
-  "G004", # Logging statement uses f-string
 ]
 unfixable = [
   "F", # pyflakes

--- a/src/ai_client.py
+++ b/src/ai_client.py
@@ -15,7 +15,7 @@ class AIClient:
 
     async def new_thread(self) -> str:
         thread = await self.client.beta.threads.create()
-        logging.debug(f"Created new thread {thread}")
+        logger.debug("Created new thread %s", thread)
         return thread.id
 
     async def get_response(self, ai_thread_id: str, text: str) -> str | None:
@@ -23,7 +23,7 @@ class AIClient:
         run = await self.client.beta.threads.runs.create_and_poll(
             thread_id=ai_thread_id, assistant_id=self.assistant_id
         )
-        logger.info(f"Run completed: {run.status=}")
+        logger.info("Run completed: %s", run.status)
         if run.status == "completed":
             messages = await self.client.beta.threads.messages.list(thread_id=ai_thread_id)
             return messages.data[0].content[0].text.value

--- a/src/bot/handlers/base_handlers.py
+++ b/src/bot/handlers/base_handlers.py
@@ -1,8 +1,10 @@
 import logging
+
 from urllib.parse import urlencode
 
 import aiogram.utils.formatting
 import openai
+
 from aiogram import F, Router, types
 from aiogram.enums import ParseMode
 from aiogram.exceptions import TelegramBadRequest
@@ -30,6 +32,8 @@ from bot.keyboards import (
 )
 from bot.md_utils import refactor_string
 
+logger = logging.getLogger(__name__)
+
 router = Router()
 
 
@@ -54,7 +58,7 @@ async def start_message(message: types.Message, state: FSMContext) -> None:
 async def ai_leonardo_handler_start(callback: types.CallbackQuery, state: FSMContext):
     await state.set_state(StatesBot.IN_AI_DIALOG)
     await callback.message.edit_text(
-        "Напишите своё сообщение в чат чтобы продолжить диалог," " или начните новый диалог нажав на кнопку ниже",
+        "Напишите своё сообщение в чат чтобы продолжить диалог, или начните новый диалог нажав на кнопку ниже",
         reply_markup=ai_kbd,
     )
 
@@ -76,8 +80,9 @@ async def main_menu_handler(callback: types.CallbackQuery, callback_data: MainMe
                 reply_markup=back_kbd,
             )
         case MainMenuBtns.SCHEDULE_CONSULTATION:
-            link = f"https://wa.me/79213713864?{urlencode({"text":
-                                                               "Здравствуйте! Я хочу записаться на консультацию к Стайсупову Валерию Юрьевичу."})}"
+            link = f"https://wa.me/79213713864?{
+                urlencode({'text': 'Здравствуйте! Я хочу записаться на консультацию к Стайсупову Валерию Юрьевичу.'})
+            }"
             escaped_link = aiogram.html.link("ссылке", link)
             await callback.message.edit_text(
                 f"Вы можете записаться на консультацию в WhatsApp по {escaped_link}\n\n"
@@ -86,12 +91,10 @@ async def main_menu_handler(callback: types.CallbackQuery, callback_data: MainMe
                 reply_markup=back_kbd,
             )
         case MainMenuBtns.SCHEDULE_SURGERY:
-            link = f"https://wa.me/79213713864?{urlencode({"text": "Здравствуйте! Я хочу записаться на операцию к Стайсупову Валерию Юрьевичу."})}"
+            link = f"https://wa.me/79213713864?{urlencode({'text': 'Здравствуйте! Я хочу записаться на операцию к Стайсупову Валерию Юрьевичу.'})}"
             escaped_link = aiogram.html.link("ссылке", link)
             await callback.message.edit_text(
-                f"Вы можете записаться на операцию в WhatsApp по {escaped_link}\n\n"
-                f""
-                f"Или по телефону: +7-812-403-02-01",
+                f"Вы можете записаться на операцию в WhatsApp по {escaped_link}\n\nИли по телефону: +7-812-403-02-01",
                 reply_markup=back_kbd,
             )
 
@@ -142,7 +145,7 @@ async def ai_menu_handler(
         try:
             await ai_client.delete_thread(data["ai_thread_id"])
         except openai.NotFoundError:
-            logging.warning(f"Thread {data['ai_thread_id']} not found")
+            logger.warning("Thread %s not found", data["ai_thread_id"])
 
     new_thread_id = await ai_client.new_thread()
     await state.update_data(ai_thread_id=new_thread_id)
@@ -162,7 +165,7 @@ async def ai_leonardo_handler(message: types.Message, ai_client: AIClient, setti
         try:
             response = await ai_client.get_response(new_thread_id, message.text)
         except openai.NotFoundError:
-            logging.warning(f"Thread {data['ai_thread_id']} not found")
+            logger.warning("Thread %s not found", data["ai_thread_id"])
             response = None
             await state.update_data(ai_thread_id=None)
 

--- a/src/bot/handlers/errors_handler.py
+++ b/src/bot/handlers/errors_handler.py
@@ -9,6 +9,8 @@ from aiogram import Router, html
 
 from config import Settings
 
+logger = logging.getLogger(__name__)
+
 if typing.TYPE_CHECKING:
     from aiogram.types.error_event import ErrorEvent
 
@@ -28,6 +30,6 @@ async def error_handler(error_event: "ErrorEvent", bot: aiogram.Bot, settings: S
         f"🚨 <b>An error occurred</b> 🚨\n\n"
         f"<b>Type:</b> {exc_name}\n<b>Message:</b> {exc_info}\n\n<b>Traceback:</b>\n<code>{tb}</code>"
     )
-    logging.exception("Exception:", exc_info=exc_info)
+    logger.exception("Exception:", exc_info=exc_info)
 
     await bot.send_message(settings.ADMIN, error_message)

--- a/src/bot/md_utils.py
+++ b/src/bot/md_utils.py
@@ -7,7 +7,8 @@ def clean(response: str):
 
 def escape_markdown_v2(text: str) -> str:
     escape_chars = r"_*[]()~`>#+-=|{}.!"
-    return re.sub(r"([%s])" % re.escape(escape_chars), r"\\\1", text)
+    pattern = rf"([{re.escape(escape_chars)}])"
+    return re.sub(pattern, r"\\\1", text)
 
 
 def escape_stars(s):

--- a/src/bot/middlewares/updates_dumper_middleware.py
+++ b/src/bot/middlewares/updates_dumper_middleware.py
@@ -8,6 +8,8 @@ from aiogram import BaseMiddleware
 from aiogram.dispatcher.event.bases import UNHANDLED
 from aiogram.types import TelegramObject, Update
 
+logger = logging.getLogger(__name__)
+
 
 class UpdatesDumperMiddleware(BaseMiddleware):
     async def __call__(
@@ -15,8 +17,8 @@ class UpdatesDumperMiddleware(BaseMiddleware):
     ) -> Any:
         json_event = event.model_dump_json(exclude_unset=True)
 
-        logging.debug(json_event)
+        logger.debug(json_event)
         res = await handler(event, data)
         if res is UNHANDLED:
-            logging.warning("UNHANDLED")
+            logger.warning("UNHANDLED")
         return res

--- a/src/main.py
+++ b/src/main.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 import logging.config
 
 from pathlib import Path
@@ -17,6 +18,8 @@ from bot.internal.notify_admin import on_shutdown_notify, on_startup_notify
 from bot.middlewares.updates_dumper_middleware import UpdatesDumperMiddleware
 from config import Settings, get_logging_config
 
+logger = logging.getLogger(__name__)
+
 
 async def set_bot_commands(bot: Bot) -> None:
     default_commands = [BotCommand(command="/start", description="Главное меню")]
@@ -32,7 +35,7 @@ async def main():
     settings = Settings()
 
     bot = Bot(token=settings.BOT_TOKEN.get_secret_value(), default=DefaultBotProperties(parse_mode=ParseMode.HTML))
-    logging.info("bot started")
+    logger.info("bot started")
     storage = RedisStorage.from_url(settings.REDIS_URL.unicode_string())
 
     ai_client = AIClient(settings.OPENAI_API_KEY.get_secret_value(), settings.ASSISTANT_ID.get_secret_value())


### PR DESCRIPTION
## Summary
- add GitHub workflow to run ruff formatting and linting
- run ruff formatter on bot handlers
- fix ruff linting errors: use module loggers and format strings
- enable ruff rule G004 and fix logging format
- remove several ignores to enable more ruff checks

## Testing
- `ruff format src tests --check`
- `ruff check src tests`


------
https://chatgpt.com/codex/tasks/task_e_6873713025d08333b2907dc4ef0441d5