### PR TITLE
Improve CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,11 +7,10 @@ on:
     branches: [main]
 
 permissions:
-  contents: read          # читаем код
-  pages: write            # деплоим Pages
-  id-token: write         # OIDC-токен для Pages
+  contents: read
+  pages: write
+  id-token: write
 
-# ----------  Lint  ----------
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -26,21 +25,22 @@ jobs:
       - run: ruff format src tests --check
       - run: ruff check src tests
 
-# ----------  Build badge и упаковка Pages  ----------
   build-pages:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.11, 3.12]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      # 1️⃣ ОБЯЗАТЕЛЬНО — подготавливает метаданные Pages
       - name: Configure GitHub Pages
-        uses: actions/configure-pages@v5   #  [oai_citation:0‡GitHub Docs](https://docs.github.com/en/pages/getting-started-with-github-pages/using-custom-workflows-with-github-pages)
+        uses: actions/configure-pages@v5
 
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: ${{ matrix.python-version }}
 
       - name: Install deps & run tests
         run: |
@@ -50,28 +50,30 @@ jobs:
           pytest --cov=src --cov-report=xml:coverage.xml
 
       - name: Generate coverage badge
+        if: matrix.python-version == '3.11'
         run: |
           genbadge coverage -i coverage.xml -o coverage.svg
 
       - name: Prepare public dir
+        if: matrix.python-version == '3.11'
         run: |
           mkdir public
           mv coverage.svg public/
 
-      # 2️⃣ Упаковываем артефакт «github-pages»
       - name: Upload Pages artifact
+        if: matrix.python-version == '3.11'
         uses: actions/upload-pages-artifact@v3
         with:
           path: public
 
-# ----------  Deploy  ----------
   deploy:
-    needs: build-pages               # артефакт уже готов
+    needs: build-pages
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4   #  [oai_citation:1‡GitHub Docs](https://docs.github.com/en/pages/getting-started-with-github-pages/using-custom-workflows-with-github-pages)
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - run: ruff format src tests --check
       - run: ruff check src tests
 
-  build-pages:
+  tests:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -33,10 +33,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Configure GitHub Pages
-        uses: actions/configure-pages@v5
-
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
@@ -49,25 +45,35 @@ jobs:
           pip install pytest pytest-cov genbadge[coverage]
           pytest --cov=src --cov-report=xml:coverage.xml
 
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-${{ matrix.python-version }}
+          path: coverage.xml
+
+      - name: Configure GitHub Pages
+        if: matrix.python-version == '3.11' && github.ref == 'refs/heads/main' && github.event_name == 'push'
+        uses: actions/configure-pages@v5
+
       - name: Generate coverage badge
-        if: matrix.python-version == '3.11'
+        if: matrix.python-version == '3.11' && github.ref == 'refs/heads/main' && github.event_name == 'push'
         run: |
           genbadge coverage -i coverage.xml -o coverage.svg
 
       - name: Prepare public dir
-        if: matrix.python-version == '3.11'
+        if: matrix.python-version == '3.11' && github.ref == 'refs/heads/main' && github.event_name == 'push'
         run: |
           mkdir public
           mv coverage.svg public/
 
       - name: Upload Pages artifact
-        if: matrix.python-version == '3.11'
+        if: matrix.python-version == '3.11' && github.ref == 'refs/heads/main' && github.event_name == 'push'
         uses: actions/upload-pages-artifact@v3
         with:
           path: public
 
   deploy:
-    needs: build-pages
+    needs: tests
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     environment:


### PR DESCRIPTION
## Summary
- extend `build-pages` job to test Python 3.11 and 3.12
- limit deploy job to pushes on `main`
- remove comments in the workflow file
- restore README instructions for `example.env`

## Testing
- `pre-commit run --files README.md .github/workflows/ci.yml example.env`
- `pytest -q`
- `ruff format src tests --check`
- `ruff check src tests`


------
https://chatgpt.com/codex/tasks/task_e_6874c3a071a48333ae3a28ec2f31c47f