### PR TITLE
Add admin chat reset button

### DIFF
--- a/src/bot/handlers/base_handlers.py
+++ b/src/bot/handlers/base_handlers.py
@@ -21,6 +21,8 @@ from bot.keyboards import (
     AfterSurgeryMenuOption,
     AIMenuBtns,
     AIMenuOption,
+    AdminMenuBtns,
+    AdminMenuOption,
     MainMenuBtns,
     MainMenuOption,
     SurgeryMenuBtns,
@@ -28,6 +30,7 @@ from bot.keyboards import (
     after_surgery_kbd,
     ai_kbd,
     before_surgery_kbd,
+    start_admin_kbd,
     start_kbd,
 )
 from bot.md_utils import refactor_string
@@ -49,9 +52,10 @@ def get_start_text(full_name: str):
 
 
 @router.message(CommandStart())
-async def start_message(message: types.Message, state: FSMContext) -> None:
+async def start_message(message: types.Message, state: FSMContext, settings) -> None:
     await state.set_state()
-    await message.answer(get_start_text(message.from_user.full_name), reply_markup=start_kbd)
+    kb = start_admin_kbd if message.from_user.id == settings.ADMIN else start_kbd
+    await message.answer(get_start_text(message.from_user.full_name), reply_markup=kb)
 
 
 @router.callback_query(MainMenuOption.filter(F.action == MainMenuBtns.AI_LEONARDO))
@@ -100,7 +104,7 @@ async def main_menu_handler(callback: types.CallbackQuery, callback_data: MainMe
 
 
 @router.callback_query(SurgeryMenuOption.filter())
-async def analyze_list_handler(callback: types.CallbackQuery, callback_data: SurgeryMenuOption):
+async def analyze_list_handler(callback: types.CallbackQuery, callback_data: SurgeryMenuOption, settings) -> None:
     match callback_data.action:
         case SurgeryMenuBtns.ANALYZE_LIST:
             fname = "data/Список Анализов.pdf"
@@ -108,7 +112,8 @@ async def analyze_list_handler(callback: types.CallbackQuery, callback_data: Sur
         case SurgeryMenuBtns.MEDICINE_AFTER:
             await callback.message.edit_text("Лекарства после операции", reply_markup=after_surgery_kbd)
         case SurgeryMenuBtns.BACK:
-            await callback.message.edit_text(get_start_text(callback.from_user.full_name), reply_markup=start_kbd)
+            kb = start_admin_kbd if callback.from_user.id == settings.ADMIN else start_kbd
+            await callback.message.edit_text(get_start_text(callback.from_user.full_name), reply_markup=kb)
 
 
 @router.callback_query(AfterSurgeryMenuOption.filter())
@@ -132,11 +137,12 @@ async def after_surgery_handler(callback: types.CallbackQuery, callback_data: Af
 
 @router.callback_query(AIMenuOption.filter())
 async def ai_menu_handler(
-    callback: types.CallbackQuery, ai_client: AIClient, state: FSMContext, callback_data: AIMenuOption
-):
+    callback: types.CallbackQuery, ai_client: AIClient, state: FSMContext, callback_data: AIMenuOption, settings
+) -> None:
     if callback_data.action == AIMenuBtns.BACK:
         await state.set_state()
-        await callback.message.edit_text(get_start_text(callback.from_user.full_name), reply_markup=start_kbd)
+        kb = start_admin_kbd if callback.from_user.id == settings.ADMIN else start_kbd
+        await callback.message.edit_text(get_start_text(callback.from_user.full_name), reply_markup=kb)
         return
 
     data = await state.get_data()
@@ -150,6 +156,20 @@ async def ai_menu_handler(
     new_thread_id = await ai_client.new_thread()
     await state.update_data(ai_thread_id=new_thread_id)
     await callback.message.answer("Чем я могу помочь?")
+
+
+@router.callback_query(AdminMenuOption.filter())
+async def admin_menu_handler(
+    callback: types.CallbackQuery, callback_data: AdminMenuOption, state: FSMContext, settings
+) -> None:
+    if callback.from_user.id != settings.ADMIN:
+        await callback.answer("Недостаточно прав", show_alert=True)
+        return
+
+    if callback_data.action == AdminMenuBtns.CLEAR_CONTEXTS:
+        await state.storage.redis.flushdb()
+        await state.set_state()
+        await callback.message.edit_text("Контекст всех пользователей очищен.", reply_markup=start_admin_kbd)
 
 
 @router.message(StatesBot.IN_AI_DIALOG)

--- a/src/bot/keyboards.py
+++ b/src/bot/keyboards.py
@@ -47,7 +47,15 @@ class AIMenuOption(CallbackData, prefix="ai_menu"):
     action: AIMenuBtns
 
 
-def _build_start_kbd():
+class AdminMenuBtns(IntEnum):
+    CLEAR_CONTEXTS = auto()
+
+
+class AdminMenuOption(CallbackData, prefix="admin_menu"):
+    action: AdminMenuBtns
+
+
+def _build_start_kbd(is_admin: bool = False):
     kb = InlineKeyboardBuilder()
     kb.button(text="Разговор с моей цифровой копией", callback_data=MainMenuOption(action=MainMenuBtns.AI_LEONARDO))
     kb.button(text="Перед операцией", callback_data=MainMenuOption(action=MainMenuBtns.BEFORE_SURGERY))
@@ -57,6 +65,9 @@ def _build_start_kbd():
     )
     kb.button(text="Записаться на операцию", callback_data=MainMenuOption(action=MainMenuBtns.SCHEDULE_SURGERY))
     kb.adjust(1, 2, 2)
+    if is_admin:
+        kb.button(text="Очистить контекст", callback_data=AdminMenuOption(action=AdminMenuBtns.CLEAR_CONTEXTS))
+        kb.adjust(1)
     return kb.as_markup()
 
 
@@ -89,6 +100,7 @@ def _ai_kbd():
 
 
 start_kbd = _build_start_kbd()
+start_admin_kbd = _build_start_kbd(is_admin=True)
 before_surgery_kbd = _before_surgery_kbd()
 after_surgery_kbd = _after_surgery_kbd()
 ai_kbd = _ai_kbd()


### PR DESCRIPTION
## Summary
- add admin menu button to clear all chat contexts
- generate start keyboard based on user's admin status
- show admin keyboard where applicable
- implement handler that flushes redis storage

## Testing
- `ruff format src/bot/keyboards.py src/bot/handlers/base_handlers.py`
- `PYTHONPATH=src pytest -q`

Pre-commit was not run because the `pre-commit` package was missing and couldn't be installed without internet access.

------
https://chatgpt.com/codex/tasks/task_e_68751b6dda0c83339c0e4db540d4c79c