### PR TITLE
Track message origin in logs

### DIFF
--- a/src/bot/global_ctx.py
+++ b/src/bot/global_ctx.py
@@ -1,0 +1,17 @@
+from aiogram import Bot
+from aiogram.fsm.context import FSMContext
+from aiogram.fsm.storage.base import BaseStorage, StorageKey
+
+
+def get_global_context(bot: Bot, storage: BaseStorage) -> FSMContext:
+    """Return FSM context for storing global bot data."""
+    key = StorageKey(bot_id=bot.id, chat_id=0, user_id=0, destiny="global")
+    return FSMContext(storage=storage, key=key)
+
+
+async def init_global(storage: BaseStorage, bot: Bot) -> None:
+    """Initialize global context with default values."""
+    ctx = get_global_context(bot, storage)
+    data = await ctx.get_data()
+    if "log_user_message_map" not in data:
+        await ctx.update_data(log_user_message_map={})

--- a/src/main.py
+++ b/src/main.py
@@ -12,6 +12,7 @@ from aiogram.fsm.storage.redis import RedisStorage
 from aiogram.types import BotCommand
 
 from ai_client import AIClient
+from bot.global_ctx import init_global
 from bot.handlers.base_handlers import router as base_router
 from bot.handlers.errors_handler import router as errors_router
 from bot.internal.notify_admin import on_shutdown_notify, on_startup_notify
@@ -39,6 +40,7 @@ async def main():
     storage = RedisStorage.from_url(settings.REDIS_URL.unicode_string())
 
     ai_client = AIClient(settings.OPENAI_API_KEY.get_secret_value(), settings.ASSISTANT_ID.get_secret_value())
+    await init_global(storage, bot)
 
     dispatcher = Dispatcher(
         storage=storage, events_isolation=SimpleEventIsolation(), ai_client=ai_client, settings=settings


### PR DESCRIPTION
## Summary
- create `global_ctx` utility for global FSM context
- initialize global context in `main`
- store user message mapping in global context from handler
- forward moderator replies from log chat to original users
- move moderator reply checks into decorator filters
- log when user and moderator messages are processed

## Testing
- `ruff format src/bot/handlers/base_handlers.py src/bot/global_ctx.py src/main.py`
- `ruff check --fix src/bot/handlers/base_handlers.py src/bot/global_ctx.py src/main.py`
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b0f00c2c883339ceed9fc5502317c